### PR TITLE
refactor: enhance GitHub authentication flow and redirect handling

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,17 +1,18 @@
 import {
+  Body,
   Controller,
+  Get,
   Post,
+  Redirect,
   Request,
   UseGuards,
-  Get,
-  Body,
 } from '@nestjs/common';
+import { RequestWithUser } from 'src/types/global';
+import { CreateUserDto } from 'src/user/user.validation';
 import { AuthService } from './auth.service';
 import { AuthLoginDto } from './auth.validation';
-import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { GitHubAuthGuard } from './guards/github-auth.guard';
-import { CreateUserDto } from 'src/user/user.validation';
-import { RequestWithUser } from 'src/types/global';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -36,9 +37,11 @@ export class AuthController {
 
   @Get('github/callback')
   @UseGuards(GitHubAuthGuard)
+  @Redirect(process.env.GITHUB_CALLBACK_FRONTEND_REDIRECT, 302)
   async githubCallback(@Request() req) {
-    const token = await this.authService.login(req.user);
-    return { token };
+    const { accessToken } = this.authService.login(req.user);
+    const redirectUrl = this.authService.redirectToFrontend(accessToken);
+    return { url: redirectUrl };
   }
 
   @Get('github')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -11,6 +11,7 @@ import { CreateUserDto } from 'src/user/user.validation';
 
 @Injectable()
 export class AuthService {
+  private redirectUrl = process.env.GITHUB_CALLBACK_FRONTEND_REDIRECT as string;
   constructor(
     private jwtService: JwtService,
     private userService: UserService,
@@ -28,6 +29,10 @@ export class AuthService {
     const payload = { sub: user.id, email: user.email };
     const accessToken = this.jwtService.sign(payload);
     return { accessToken };
+  }
+
+  redirectToFrontend(token: string) {
+    return `${this.redirectUrl}?token=${token}`;
   }
 
   async register(createUserDto: CreateUserDto): Promise<IUser> {

--- a/src/auth/strategy/github.strategy.ts
+++ b/src/auth/strategy/github.strategy.ts
@@ -19,6 +19,10 @@ export class GitHubStrategy extends PassportStrategy(Strategy, 'github') {
   }
 
   async validate(accessToken: string, refreshToken: string, profile: any) {
-    return this.authService.findOrCreateGitHubUser(profile);
+    const user = await this.authService.findOrCreateGitHubUser(profile);
+    return {
+      ...user,
+      accessToken,
+    };
   }
 }


### PR DESCRIPTION
This pull request includes several important changes to the authentication flow, particularly for GitHub OAuth integration. The changes streamline the redirection process after GitHub authentication and refactor some imports for better organization.

### Improvements to GitHub OAuth integration:

* [`src/auth/auth.controller.ts`](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R40-R44): Added a `@Redirect` decorator to the `githubCallback` method to redirect users to the frontend with the access token as a query parameter.
* [`src/auth/auth.service.ts`](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR34-R37): Introduced a `redirectToFrontend` method to generate the frontend URL with the access token.
* [`src/auth/strategy/github.strategy.ts`](diffhunk://#diff-742249ca8643ddbc9fe027fa6543e9ca26de1cb66f16d3340dd5d36a218c27d2L22-R26): Modified the `validate` method to include the access token in the returned user object.

### Code organization improvements:

* [`src/auth/auth.controller.ts`](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R2-R15): Refactored imports for better readability and organization.
* [`src/auth/auth.service.ts`](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR14): Added a private `redirectUrl` property to store the frontend redirect URL from environment variables.- Updated the GitHub callback in AuthController to return a redirect URL with the access token.
- Introduced a new method in AuthService to construct the redirect URL for the frontend.
- Modified the GitHub strategy to include the access token in the user object returned after validation.